### PR TITLE
added all get requests by ids

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -123,4 +123,76 @@ app.MapGet("/api/facilityminerals", () =>
     });
 });
 
+//Fetches a mineral by id
+app.MapGet("api/minerals/{id}", (int id) =>
+{
+Mineral mineral = minerals.FirstOrDefault(m => m.Id == id);
+if (mineral == null)
+{
+    return Results.NotFound();
+}
+
+return Results.Ok(new MineralDTO
+{
+    Id = mineral.Id,
+    Name = mineral.Name,
+});
+});
+
+//Fetches a facility by id
+app.MapGet("api/facilities/{id}", (int id) =>
+{
+Facility facility = facilities.FirstOrDefault(f => f.Id == id);
+if (facility == null)
+{
+    return Results.NotFound();
+}
+
+return Results.Ok(new FacilityDTO
+{
+    Id = facility.Id,
+    Name = facility.Name,
+    Active = facility.Active
+});
+});
+
+//Fetches ColonyMineral by Id
+app.MapGet("api/colonyMinerals/{id}", (int id) =>
+{
+ColonyMineral colonyMineral = colonyMinerals.FirstOrDefault(cm => cm.Id == id);
+if (colonyMineral == null)
+{
+    return Results.NotFound();
+}
+
+return Results.Ok(new ColonyMineralDTO
+{
+    Id = colonyMineral.Id,
+    ColonyId = colonyMineral.ColonyId,
+    MineralId = colonyMineral.MineralId,
+    ColonyTons = colonyMineral.ColonyTons
+
+
+});
+});
+
+//Fetches a FacilityMineral by id
+app.MapGet("api/facilityMinerals/{id}", (int id) =>
+{
+FacilityMineral facilityMineral = facilityMinerals.FirstOrDefault(fm => fm.Id == id);
+if (facilityMineral == null)
+{
+    return Results.NotFound();
+}
+
+return Results.Ok(new FacilityMineralDTO
+{
+    Id = facilityMineral.Id,
+    MineralId = facilityMineral.MineralId,
+    FacilitiesId = facilityMineral.FacilitiesId,
+    FacilityTons = facilityMineral.FacilityTons
+
+
+});
+});
 app.Run();


### PR DESCRIPTION
##  What? 
Added all the of get requests that require a single id necessary for the backend of Exomine.

## Why?
So Now we can use the get request while running our own server on the backend, and not with json-server.

## How?
Added to program.cs with more get requests the difference is I passed in int id as a parameter so It would look for a specific Id and only display that one.

## Testing?
Run the debugger in the vscode to start the server and then go into postman and make sure you are getting results for the following:
localhost:5223/api/facilities/(enter a id here)
localhost:5223/api/colonyMinerals/(enter a id here)
localhost:5223/api/minerals/(enter a id here)
localhost: 5223/api/facilityMinerals/(enter a id here)
