### PR TITLE
GET Colony for a Gov

### DIFF
--- a/Models/DTOs/GovenorsDTO.cs
+++ b/Models/DTOs/GovenorsDTO.cs
@@ -16,6 +16,6 @@ public class GovernorDTO {
     public int ColonyId {get; set;}
 
 
-    public List<ColonyDTO> Colonies {get; set;}
+    public List<ColonyDTO>? Colonies {get; set;}
        
 }

--- a/Models/DTOs/GovenorsDTO.cs
+++ b/Models/DTOs/GovenorsDTO.cs
@@ -1,14 +1,21 @@
  namespace ExomineAPIbzxnks.Models.DTOs;
 
+
  
 public class GovernorDTO {
 
+
     public int Id {get; set;}
+
 
     public string Name {get; set;}
 
+
     public bool Active {get; set;}
-    
+   
     public int ColonyId {get; set;}
 
+
+    public List<ColonyDTO> Colonies {get; set;}
+       
 }

--- a/Models/Govenors.cs
+++ b/Models/Govenors.cs
@@ -1,12 +1,19 @@
 namespace ExomineAPIbzxnks.Models;
 public class Governor {
 
+
     public int Id {get; set;}
+
 
     public string Name {get; set;}
 
+
     public bool Active {get; set;}
-    
+   
     public int ColonyId {get; set;}
+
+
+    public List<Colony> Colonies {get; set;}
+
 
 }

--- a/Models/Govenors.cs
+++ b/Models/Govenors.cs
@@ -13,7 +13,7 @@ public class Governor {
     public int ColonyId {get; set;}
 
 
-    public List<Colony> Colonies {get; set;}
+    public List<Colony>? Colonies {get; set;}
 
 
 }

--- a/Program.cs
+++ b/Program.cs
@@ -100,7 +100,7 @@ app.MapGet("/api/facilities", () =>
 
 
 //fetch ALL colonyMinerals
-app.MapGet("/api/colonyminerals", () =>
+app.MapGet("/api/colonyMinerals", () =>
 {
     return colonyMinerals.Select(cm => new ColonyMineralDTO
     {
@@ -113,7 +113,7 @@ app.MapGet("/api/colonyminerals", () =>
 
 //fetch ALL facilityMinerals
 
-app.MapGet("/api/facilityminerals", (int? facilityId, int? mineralId, string? expand) =>
+app.MapGet("/api/facilityMinerals", (int? facilityId, int? mineralId, string? expand) =>
 {
     List<FacilityMineral> joinTables = facilityMinerals.ToList();
 
@@ -226,4 +226,33 @@ app.MapGet("api/facilityMinerals/{id}", (int id) =>
 
     });
 });
+
+// Fetch a single governor with their colony
+app.MapGet("/api/governors/{id}", (int id) =>
+{
+    Governor governor = governors.FirstOrDefault(g => g.Id == id);
+    if (governor == null)
+    {
+        return Results.NotFound();
+    }
+
+
+    Colony colony = colonies.FirstOrDefault(c => c.Id == governor.ColonyId);
+    var colonyDTO = colony != null ? new ColonyDTO { Id = colony.Id, Name = colony.Name } : null;
+
+
+    var governorDTO = new GovernorDTO
+    {
+        Id = governor.Id,
+        Name = governor.Name,
+        Active = governor.Active,
+        ColonyId = governor.ColonyId,
+        Colonies = colonyDTO != null ? new List<ColonyDTO> { colonyDTO } : new List<ColonyDTO>()
+    };
+
+
+    return Results.Ok(governorDTO);
+});
+
+
 app.Run();


### PR DESCRIPTION
# Description

Added a GET endpoint so a user may retrieve the expanded colony property for a specific governor.

Fixes # (changed some urls from flatcase to camelCase)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Run GET http://localhost:<port>/api/governors/{id} in Postman. You should see that specific governor with their expanded colony property. Example for governor id 1:

{
    "id": 1,
    "name": "Edward Wong Hau Pepelu Tivrusky IV",
    "active": true,
    "colonyId": 5,
    "colonies": [
        {
            "id": 5,
            "name": "Oklahoma"
        }
    ]
}

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings