### PR TITLE
Cw/feature endpoint for all minerals2

### DIFF
--- a/Models/ColonyMinerals.cs
+++ b/Models/ColonyMinerals.cs
@@ -9,4 +9,6 @@ public class ColonyMineral {
     public int MineralId {get; set;}
 
     public int ColonyTons {get; set;}
+
+    
 }

--- a/Models/DTOs/ColonyMineralsDTO.cs
+++ b/Models/DTOs/ColonyMineralsDTO.cs
@@ -8,4 +8,6 @@
     public int MineralId {get; set;}
 
     public int ColonyTons {get; set;}
+
+    public MineralDTO? Mineral { get; set; }
  }

--- a/Program.cs
+++ b/Program.cs
@@ -139,7 +139,7 @@ return Results.Ok(new MineralDTO
 });
 });
 
-//Fetches a facility by id
+//Fetches a Facility by id
 app.MapGet("api/facilities/{id}", (int id) =>
 {
 Facility facility = facilities.FirstOrDefault(f => f.Id == id);
@@ -194,5 +194,25 @@ return Results.Ok(new FacilityMineralDTO
 
 
 });
+});
+
+app.MapGet("api/colonyMinerals/colony/{colonyId}", (int colonyId) => {
+    
+    ColonyMineral colonyMineral = colonyMinerals.FirstOrDefault(cm => cm.ColonyId == colonyId);
+    Mineral mineral = minerals.FirstOrDefault(m => m.Id == colonyMineral.MineralId);
+
+    return Results.Ok( new ColonyMineralDTO {
+        Id = colonyMineral.Id,
+        ColonyId = colonyMineral.ColonyId,
+        MineralId= colonyMineral.MineralId,
+        ColonyTons = colonyMineral.ColonyTons,
+        Mineral = mineral == null ? null : new MineralDTO {
+            Id = mineral.Id,
+            Name = mineral.Name
+        }
+
+
+
+    });
 });
 app.Run();

--- a/Program.cs
+++ b/Program.cs
@@ -199,6 +199,12 @@ return Results.Ok(new FacilityMineralDTO
 app.MapGet("api/colonyMinerals/colony/{colonyId}", (int colonyId) => {
     
     ColonyMineral colonyMineral = colonyMinerals.FirstOrDefault(cm => cm.ColonyId == colonyId);
+
+    if (colonyMineral == null)
+    {
+        return Results.NotFound($"No colony mineral found with colony ID");
+    }
+
     Mineral mineral = minerals.FirstOrDefault(m => m.Id == colonyMineral.MineralId);
 
     return Results.Ok( new ColonyMineralDTO {


### PR DESCRIPTION
What?
Added an endpoint for finding all minerals for a colony, so we can fetch the specific colony id and it will return the colonyMinerals for that colony id and display the minerals attached to the colony id.

Why?
So we can access the information of the minerals that are on a single colony through fetching colonyMinerals.

How?
Making a Get request to have the colony Id as a parameter and when you add the to the fetch url it will return a colonyMineral that is connected to that colony and have the minerals for it displayed.

Testing?
Run the debugger in the vscode to start the server and then go into postman and make sure you are getting results for the following:
localhost:5223/api/colonyMinerals/colony/(enter a colony id here)